### PR TITLE
Allow fetching of published objects without token

### DIFF
--- a/bco_api/api/scripts/method_specific/POST_api_objects_published.py
+++ b/bco_api/api/scripts/method_specific/POST_api_objects_published.py
@@ -1,0 +1,112 @@
+# BCOs
+from ...models import bco
+
+# User information
+from ..utilities import UserUtils
+
+# Object-level permissions
+from guardian.shortcuts import get_objects_for_user
+
+# Concatenating QuerySets
+from itertools import chain
+
+# Responses
+from rest_framework import status
+from rest_framework.response import Response
+
+# Below is helper code to deal with how we are allowing non standard versions (i.e. 1.2 instead of 1.2.0, etc).
+import re
+import semver
+from semver import VersionInfo as Version
+from typing import Optional, Tuple
+
+# TODO: This is repeated code, should consolidate
+BASEVERSION = re.compile(
+        r"""[vV]?
+        (?P<major>0|[1-9]\d*)
+        (\.
+        (?P<minor>0|[1-9]\d*)
+        (\.
+            (?P<patch>0|[1-9]\d*)
+        )?
+        )?
+    """,
+        re.VERBOSE,
+        )
+
+
+def coerce(version: str) -> Tuple[Version, Optional[str]]:
+    """
+    Convert an incomplete version string into a semver-compatible Version
+    object
+    * Tries to detect a "basic" version string (``major.minor.patch``).
+    * If not enough components can be found, missing components are
+        set to zero to obtain a valid semver version.
+    :param str version: the version string to convert
+    :return: a tuple with a :class:`Version` instance (or ``None``
+        if it's not a version) and the rest of the string which doesn't
+        belong to a basic version.
+    :rtype: tuple(:class:`Version` | None, str)
+    """
+    match = BASEVERSION.search(version)
+    if not match:
+        return (None, version)
+
+    ver = {
+            key: 0 if value is None else value for key, value in match.groupdict().items()
+            }
+    ver = Version(**ver)
+    rest = match.string[match.end():]  # noqa:E203
+    return ver, rest
+
+
+def POST_api_objects_published():
+    """
+    Get All published objects (publicly available)
+    """
+
+    published = bco.objects.filter(state='PUBLISHED').values()
+    unique_published = []
+
+    # E.g.
+    # published[0]["contents"]["object_id"] = 'http://127.0.0.1:8000/BCO_000010/1.0'
+
+    bcos = { }
+    for p in published:
+        # TODO: We should move this out of a try except and try to handle various situations, this is currently
+        #       assuming that the format is http://URL:PORT/BCO NAME/BCO VERSION - this may not always be true
+        try:
+            bco_url, bco_id_name, bco_id_version = p["contents"]["object_id"].rsplit("/", 2)
+        except Exception as e:
+            print("Biocompute Name, Version, and URL not formatted as expected: {}".format(e))
+            return Response(status=status.HTTP_400_BAD_REQUEST)
+
+        if bco_url in bcos:
+            # Other version of this BCO object exists
+            current_version = bcos[bco_url]["bco_version"]
+
+            if semver.compare(bco_id_version, current_version, key=coerce):
+                # New one is newer version, set:
+                bcos[bco_url] = {
+                        "bco_name"   : bco_id_name,
+                        "bco_version": bco_id_version,
+                        "bco_object" : p
+                        }
+
+            else:
+                # Do nothing
+                pass
+        else:
+            # Not in dictionary yet
+            bcos[bco_url] = {
+                    "bco_name"   : bco_id_name,
+                    "bco_version": bco_id_version,
+                    "bco_object" : p
+                    }
+    for key, value in bcos.items():
+        unique_published.append(value["bco_object"])
+
+    return Response(
+            data=unique_published,
+            status=status.HTTP_200_OK
+            )

--- a/bco_api/api/urls.py
+++ b/bco_api/api/urls.py
@@ -2,7 +2,7 @@ from django.urls import path, include, re_path
 from .views import ApiAccountsActivateUsernameTempIdentifier, ApiAccountsDescribe, ApiAccountsNew, ApiGroupsCreate, \
     ApiGroupsDelete, ApiGroupsModify, \
     ApiObjectsDraftsCreate, ApiObjectsDraftsModify, ApiObjectsDraftsPermissions, ApiObjectsDraftsPermissionsSet, \
-    ApiObjectsDraftsPublish, ApiObjectsDraftsRead, \
+    ApiObjectsDraftsPublish, ApiObjectsDraftsRead, ApiObjectsPublished, \
     ApiObjectsSearch, ApiObjectsToken, ApiPrefixesCreate, ApiPrefixesDelete, ApiPrefixesPermissionsSet, \
     ApiPrefixesToken, ApiPrefixesTokenFlat, \
     ApiPrefixesUpdate, ApiObjectsPublish, ApiObjectsDraftsToken, ApiPublicDescribe, DraftObjectId, ObjectIdRootObjectId, \
@@ -148,6 +148,7 @@ if PUBLISH_ONLY == 'True':
         path('api/redocs/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
         path('<str:object_id_root>/<str:object_id_version>', ObjectIdRootObjectIdVersion.as_view()),
         path('api/objects/publish/', ApiObjectsPublish.as_view()),
+        path('api/objects/published/', ApiObjectsPublished.as_view()),
         path('api/public/describe/', ApiPublicDescribe.as_view())
     ]
 
@@ -219,6 +220,9 @@ elif PUBLISH_ONLY == 'False':
              ),
         path('api/objects/token/',
              ApiObjectsToken.as_view()
+             ),
+        path('api/objects/published/',
+             ApiObjectsPublished.as_view()
              ),
         path('api/prefixes/create/',
              ApiPrefixesCreate.as_view()

--- a/bco_api/api/views.py
+++ b/bco_api/api/views.py
@@ -34,6 +34,7 @@ from .scripts.method_specific.POST_api_objects_drafts_publish import POST_api_ob
 from .scripts.method_specific.POST_api_objects_drafts_read import POST_api_objects_drafts_read
 from .scripts.method_specific.POST_api_objects_drafts_token import POST_api_objects_drafts_token
 from .scripts.method_specific.POST_api_objects_publish import POST_api_objects_publish
+from .scripts.method_specific.POST_api_objects_published import POST_api_objects_published
 from .scripts.method_specific.POST_api_objects_search import POST_api_objects_search
 from .scripts.method_specific.POST_api_objects_token import POST_api_objects_token
 from .scripts.method_specific.POST_api_prefixes_create import POST_api_prefixes_create
@@ -795,8 +796,53 @@ class ApiObjectsToken(APIView):
         # the Authorization header is required.
         return POST_api_objects_token(rqst=request)
 
-    # TODO: Should change to get?
 
+class ApiObjectsPublished(APIView):
+    """
+    Get Published BCOs
+
+    --------------------
+
+    Get all BCOs available for a specific token, including published ones.
+    """
+
+    # auth = []
+    # auth.append(
+    #         openapi.Parameter('Token', openapi.IN_HEADER, description="Authorization Token", type=openapi.TYPE_STRING))
+
+    # request_body = openapi.Schema(
+    #     type=openapi.TYPE_OBJECT,
+    #     title="Get BCO Schema",
+    #     description="Parameters that are supported when fetching a BCOs.",
+    #     required=['POST_api_objects_token'],
+    #     properties={
+    #         'POST_api_objects_token': openapi.Schema(
+    #             type=openapi.TYPE_OBJECT,
+    #             required=['fields'],
+    #             properties={
+    #                 'fields': openapi.Schema(
+    #                     type=openapi.TYPE_ARRAY,
+    #                     items=openapi.Schema(
+    #                         type=openapi.TYPE_STRING,
+    #                         description="Field to return",
+    #                         enum=['contents', 'last_update', 'object_class', 'object_id', 'owner_group', 'owner_user',
+    #                               'prefix', 'schema', 'state']
+    #                     ),
+    #                     description="Fields to return.")
+    #             })})
+
+    # Anyone can view a published object
+    authentication_classes = []
+    permission_classes = []
+
+    # @swagger_auto_schema(request_body=request_body, responses={
+    #         200: "Fetch BCOs is successful.",
+    #         400: "Bad request.",
+    #         403: "Invalid token."
+    #         }, tags=["BCO Management"])
+    def get(self) -> Response:
+        return POST_api_objects_published()
+        # return POST_api_objects_token(rqst=request)
 
 class ApiPrefixesCreate(APIView):
     """

--- a/bco_api/api/views.py
+++ b/bco_api/api/views.py
@@ -839,7 +839,8 @@ class ApiObjectsPublished(APIView):
     #         400: "Bad request.",
     #         403: "Invalid token."
     #         }, tags=["BCO Management"])
-    def get(self) -> Response:
+    def get(self, request) -> Response:
+        # import pdb; pdb.set_trace()
         return POST_api_objects_published()
         # return POST_api_objects_token(rqst=request)
 


### PR DESCRIPTION
This MR adds a new endpoint which allows for the fetching of published BCOs without a token.

Closes #46 Closes #43 