### PR TITLE
fix to support fetching objects that are published via BCO id and opt…

### DIFF
--- a/bco_api/api/urls.py
+++ b/bco_api/api/urls.py
@@ -146,8 +146,8 @@ if PUBLISH_ONLY == 'True':
         re_path(r'^api/doc(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
         path('api/docs/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
         path('api/redocs/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
-        path('<str:object_id_root>', ObjectIdRootObjectId.as_view()),
-        path('<str:object_id_root>/<str:object_id_version>', ObjectIdRootObjectIdVersion.as_view()),
+        path('bco/<str:object_id_root>', ObjectIdRootObjectId.as_view()),
+        path('bco/<str:object_id_root>/<str:object_id_version>', ObjectIdRootObjectIdVersion.as_view()),
         path('api/objects/publish/', ApiObjectsPublish.as_view()),
         path('api/objects/published/', ApiObjectsPublished.as_view()),
         path('api/public/describe/', ApiPublicDescribe.as_view())
@@ -165,13 +165,13 @@ elif PUBLISH_ONLY == 'False':
              schema_view.with_ui('redoc', cache_timeout=0),
              name='schema-redoc'
              ),
-        path('draft/<str:draft_object_id>',
+        path('<str:draft_object_id>',
              DraftObjectId.as_view()
              ),
-        path('<str:object_id_root>',
+        path('bco/<str:object_id_root>',
              ObjectIdRootObjectId.as_view()
              ),
-        path('<str:object_id_root>/<str:object_id_version>',
+        path('bco/<str:object_id_root>/<str:object_id_version>',
              ObjectIdRootObjectIdVersion.as_view()
              ),
         path('api/accounts/activate/<str:username>/<str:temp_identifier>',


### PR DESCRIPTION
closes 37 

Allows the BCO API to properly be able to report published BCOs by object id and optionally version without a token.