### PR TITLE
Remove button from unsuccessful activation page

### DIFF
--- a/bco_api/api/templates/api/account_activation_message.html
+++ b/bco_api/api/templates/api/account_activation_message.html
@@ -31,10 +31,11 @@
         <div id = 'message'>
         {% if activation_success == True %}
             <p>Successful activation! You may close this window or open Portal in a new tab.</p>
+            <button type = 'button'><a href = {{ activation_url }}>Open Portal in new tab</a></button>
         {% else %}
             <p>Unsuccessful activation!  The account may not have been requested or may have already been activated.  Please request another activation e-mail on the Portal.</p>
         {% endif %}
-            <button type = 'button'><a href = {{ activation_url }}>Open Portal in new tab</a></button>
+            
         </div>
   </body>
 </html>


### PR DESCRIPTION
Close #113 

Changes to be committed:
	modified:   api/templates/api/account_activation_message.html