### PR TITLE
Disallow modifying DRAFT object ID

### DIFF
--- a/bco_api/api/scripts/utilities/DbUtils.py
+++ b/bco_api/api/scripts/utilities/DbUtils.py
@@ -740,6 +740,15 @@ class DbUtils:
                 + parameters["object_id"]
                 + " has already been created on this server.",
             },
+            "409_draft_object_id_conflict": {
+                "request_status": "FAILURE",
+                "status_code": "409",
+                "message": "The provided object_id "
+                + parameters["object_id"]
+                + " does not match the saved draft object_id "
+                + parameters["draft_object_id"]
+                + ". Once a draft is created you can not change the object id.",
+            },
             "409_object_id_conflict": {
                 "request_status": "FAILURE",
                 "status_code": "409",


### PR DESCRIPTION
Update to catch and respond to attempts to modify the DRAFT object_id.

Changes to be committed:
	modified:   api/scripts/method_specific/POST_api_objects_drafts_modify.py
	modified:   api/scripts/utilities/DbUtils.py