### PR TITLE
Deep Linking

### DIFF
--- a/bco_api/bco_api/settings.py
+++ b/bco_api/bco_api/settings.py
@@ -178,7 +178,8 @@ TEMPLATES = [
 SWAGGER_SETTINGS = {
     "SECURITY_DEFINITIONS": {
         "Bearer": {"type": "apiKey", "name": "Authorization", "in": "header"}
-    }
+    },
+    "DEEP_LINKING": True
 }
 
 REDOC_SETTINGS = {"LAZY_RENDERING": False}

--- a/bco_api/server.conf
+++ b/bco_api/server.conf
@@ -7,7 +7,7 @@ production=False
 
 # DB Version
 [VERSION]
-version=22.06
+version=22.08
 
 # NOTE:  Valid values are True or False (note the capitalization).
 # Is this a publish-only server?


### PR DESCRIPTION
Automatically update the fragment part of the URL with permalinks to the currently selected operation. Related to https://github.com/biocompute-objects/userdb/issues/28

	modified:   bco_api/bco_api/settings.py
	modified:   bco_api/server.conf