### PR TITLE
Auth_add

### DIFF
--- a/tests/test_views/test_get_objectid.py
+++ b/tests/test_views/test_get_objectid.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+"""Get ObjectID
+Tests for 'Successful request with valid object id' (200), 
+'Request with a non-existent object ID' (404), 'unauthorized- Request without authentication credentials' (401),
+'Forbidden- Request with valid object ID but unauthorized user' (403)
+"""
+
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+class BCOViewTestCase(TestCase):
+    fixtures = ['tests/fixtures/test_data']
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_view_published_bco_success(self):
+        # Successful request with valid object ID
+        object_id = "TEST_000001"
+        response = self.client.get(f'/api/{object_id}/')
+        self.assertEqual(response.status_code, 200)
+
+    def test_view_published_bco_not_found(self):
+        # Request with a non-existent object ID
+        object_id = "invalid_object_id"
+        response = self.client.get(f'/api/{object_id}/')
+        self.assertEqual(response.status_code, 404)
+
+    def test_view_published_bco_unauthorized(self):
+        # Request without authentication credentials
+        response = self.client.get('/api/TEST_000001/')
+        self.assertEqual(response.status_code, 401)
+
+    def test_view_published_bco_forbidden(self):
+        # Request with valid object ID but unauthorized user
+        # (ie-user without sufficient permissions to access the BCO)
+        object_id = "TEST_000001"
+        # Authenticate as a user without sufficient permissions ??
+        # self.client.credentials(HTTP_AUTHORIZATION='Token your_invalid_token_here')
+        response = self.client.get(f'/api/{object_id}/')
+        self.assertEqual(response.status_code, 403)


### PR DESCRIPTION
Add Authentication
Tests for 'New authentication credentials added to existing object' (200),
'Authentication credentials were created and added' (201), 'Bad request' (400),
'That object already exists for this account' (409)