### PR TITLE
Refactor the Prefix permission system

### DIFF
--- a/authentication/services.py
+++ b/authentication/services.py
@@ -190,7 +190,6 @@ def create_bcodb_user(email: str) -> User:
     
     return user
 
-
 def send_bcodb(data: str, request_info: dict):
     """
     """

--- a/biocompute/models.py
+++ b/biocompute/models.py
@@ -49,6 +49,7 @@ class Bco(models.Model):
     prefix = models.ForeignKey(Prefix, on_delete=models.CASCADE, to_field="prefix")
     owner = models.ForeignKey(
         User,
+        to_field="username",
         on_delete=models.CASCADE, 
         related_name="owned_bcos"
     )

--- a/config/services.py
+++ b/config/services.py
@@ -21,8 +21,7 @@ def legacy_api_converter(data:dict) ->dict:
             for prefix in object['prefixes']:
                 return_data.append({
                     "prefix": prefix["prefix"],
-                    "description": prefix["description"],
-                    "authorized_groups": [owner_group]
+                    "description": prefix["description"]
                 })
         return return_data
         

--- a/config/settings.py
+++ b/config/settings.py
@@ -123,18 +123,13 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-# Object-level permissions with django-guardian
-# Source: https://github.com/django-guardian/django-guardian#configuration
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
-    "guardian.backends.ObjectPermissionBackend",
 ]
 
 # --- APPLICATION --- #
 # Application definition
 
-# Token-based authentication.
-# Source: https://www.django-rest-framework.org/api-guide/authentication/#tokenau thentication
 INSTALLED_APPS = [
     "django.contrib.admin",
     "django.contrib.admindocs",
@@ -150,8 +145,6 @@ INSTALLED_APPS = [
     'rest_framework_jwt.blacklist',
     "rest_framework_swagger",
     "reset_migrations",
-    "guardian",
-    # "api",
     "authentication",
     "biocompute",
     "prefix"

--- a/docs/refactor.md
+++ b/docs/refactor.md
@@ -27,6 +27,11 @@
 ### Refactor the BCO permission system
 - same situation as prefix
 
+## Permissions
+
+- BCO has `owner`, `auth_group` and `auth_user`
+- Prefix has `owner`, and `auth_group` 
+
 ## Items to look at later
 - `authentication.apis.RegisterUserNoVerificationAPI` has no swagger or tests
 - fix email and secrets
@@ -40,3 +45,11 @@
 - unwanted swagger endpoints
 - need tests for token
 - prefix api documentation and portal docs for prefix
+
+Prefix Perms:
+	add -> create new DRAFT
+	edit -> Change existing Draft
+	delete -> Delete Draft
+	publish -> Publish Draft
+	view -> View/download 
+   ONLY if private

--- a/prefix/apis.py
+++ b/prefix/apis.py
@@ -27,10 +27,15 @@ PREFIX_SCHEMA = openapi.Schema(
                 description="A description of what this prefix should represent.  For example, the prefix 'GLY' would be related to BCOs which were derived from GlyGen workflows.",
                 example="Test prefix description."
             ),
-            "authorized_groups": openapi.Schema(
-                type=openapi.TYPE_ARRAY,
-                description="Groups which can access the BCOs using this prefix. If it is none then anyone can access.",
-                items=openapi.Schema(type=openapi.TYPE_STRING, example="")
+            "certifying_key": openapi.Schema(
+                type=openapi.TYPE_STRING,
+                description="Hash of server and date-time of creation.",
+                example="12345678910"
+            ),
+            "public": openapi.Schema(
+                type=openapi.TYPE_BOOLEAN,
+                description="Flag to set permissions.",
+                example=True
             )
         },
     )

--- a/prefix/models.py
+++ b/prefix/models.py
@@ -19,11 +19,6 @@ class Prefix(models.Model):
         on_delete=models.CASCADE,
         to_field="username"
     )
-    authorized_groups = models.ManyToManyField(
-        Group,
-        blank=True,
-        related_name='authorized_prefix'
-    )
     counter = models.IntegerField(
         default=0,
         help_text="Counter for object_id asignment"

--- a/prefix/models.py
+++ b/prefix/models.py
@@ -23,6 +23,11 @@ class Prefix(models.Model):
         default=0,
         help_text="Counter for object_id asignment"
     )
+    public = models.BooleanField(
+        default=True,
+        help_text= "Boolean field to indicate if there are restrictions on "\
+            + "the use of this prefix"
+        )
 
     def __str__(self):
         """String for representing the BCO model (in Admin site etc.)."""

--- a/prefix/selectors.py
+++ b/prefix/selectors.py
@@ -1,7 +1,57 @@
+# prefix/selectors.py
+
+"""Prefix Selectors
+
+Functions to query the database related to Prefixes
+"""
+
+from django.core.serializers import serialize
+from django.contrib.auth.models import Permission
+from django.contrib.auth.models import User
+from django.db import utils 
+from prefix.models import Prefix
+
+def get_prefix_object(prefix_name:str) -> dict:
+    """Get Prefix Object
+
+    Returns a serialized Prefix instance. If the Prefix is not public then
+    a dictionary with users and the associated Prefix permisssions will also 
+    be included.
+    """
+
+    prefix_instance = Prefix.objects.get(prefix=prefix_name)
+    prefix_object = serialize('python', [prefix_instance])[0]
+    if prefix_instance.public is False:
+        prefix_permissions = get_prefix_permissions(prefix_name)
+        prefix_object["user_permissions"] = prefix_permissions
+    return prefix_object
+
+def get_prefix_permissions(prefix_name:str) -> dict:
+    """Get Prefix Permissions
+
+    Returns a dictionary with users and the associated Prefix permisssions.
+    """
+
+    users_permissions = {}
+    perms = []
+    for perm in [ "view", "add", "change", "delete", "publish"]:
+        codename = f"{perm}_{prefix_name}"
+        try:
+            perms.append(Permission.objects.get(codename__exact=codename))
+        except utils.IntegrityError:
+            # The permissions doesn't exist.
+            pass
 
 
-def is_accessible_by(self, user):
-    """If no authorized_groups are specified, it's accessible by everyone"""
-    if self.authorized_users.exists():
-        return self.authorized_users.filter(id=user.id).exists()
-    return True
+    for perm in perms:
+        users_with_perm = User.objects.filter(user_permissions=perm).prefetch_related('user_permissions')
+        for user in users_with_perm:
+            # Initialize the user entry in the dictionary if not already present
+            if user.username not in users_permissions:
+                users_permissions[user.username] = []
+
+            # Add the permission codename to the user's permissions list, avoiding duplicates
+            if perm.codename not in users_permissions[user.username]:
+                users_permissions[user.username].append(perm.codename)
+    
+    return users_permissions

--- a/prefix/selectors.py
+++ b/prefix/selectors.py
@@ -11,6 +11,26 @@ from django.contrib.auth.models import User
 from django.db import utils 
 from prefix.models import Prefix
 
+def get_user_prefixes(user: User) -> dict:
+    """Get User Prefixes
+
+    Returns a dictionary with the users associated Prefix permisssions.
+    """
+    prefix_permissions = {
+        "public_permissions":[],
+        "not_public_permissions": []
+    }
+
+    public_prefixes = Prefix.objects.filter(public=True)
+    for prefix_instance in public_prefixes:
+        prefix_permissions["public_permissions"].append(prefix_instance.pk)
+    for permission in user.user_permissions.all():
+        print(permission)
+        prefix_permissions["not_public_permissions"].append(permission.name)
+
+    return  prefix_permissions
+
+
 def get_prefix_object(prefix_name:str) -> dict:
     """Get Prefix Object
 
@@ -19,7 +39,10 @@ def get_prefix_object(prefix_name:str) -> dict:
     be included.
     """
 
-    prefix_instance = Prefix.objects.get(prefix=prefix_name)
+    try:
+        prefix_instance = Prefix.objects.get(prefix=prefix_name)
+    except Prefix.DoesNotExist:
+        return None
     prefix_object = serialize('python', [prefix_instance])[0]
     if prefix_instance.public is False:
         prefix_permissions = get_prefix_permissions(prefix_name)

--- a/prefix/services.py
+++ b/prefix/services.py
@@ -6,12 +6,14 @@ from urllib.parse import urlparse
 from django.conf import settings
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
+from django.db import utils 
 from django.utils import timezone
 from prefix.models import Prefix
 from django.db import transaction
-from django.contrib.auth.models import Group, User
+from django.contrib.auth.models import User
 from django.db.models import F
 from rest_framework import serializers
+from prefix.selectors import get_prefix_permissions, get_prefix_object
 
 """Prefix Services
 
@@ -22,19 +24,18 @@ class PrefixSerializer(serializers.Serializer):
     prefix = serializers.CharField(min_length=3, max_length=5)
     description = serializers.CharField()
     authorized_groups = serializers.ListField(child=serializers.CharField(allow_blank=True), required=False)
+    user_permissions = serializers.JSONField(required=False, default={})
     public = serializers.BooleanField(required=False)
     
     def validate(self, attrs):
         """Prefix Validator
         """
 
-        errors = {}
         request = self.context.get('request')
         attrs["owner"] = request.user
         attrs['prefix'] = attrs['prefix'].upper()
         prefix_name = attrs['prefix']
 
-        # Validate Prefix name and owner
         try:
             attrs["prefix"] = Prefix.objects.get(prefix=prefix_name)
             if "create" in request.path_info:
@@ -52,24 +53,85 @@ class PrefixSerializer(serializers.Serializer):
     def create(self, validated_data):
         """Create function for Prefix
         """
-        public = validated_data.pop('public', [])
-        import pdb; pdb.set_trace()
-        prefix_instance = Prefix.objects.create(**validated_data, created=timezone.now())
 
+        validated_data.pop('user_permissions')
+        public = validated_data['public']
+        prefix_instance = Prefix.objects.create(**validated_data, created=timezone.now())
+        
+        if public is False:
+            create_permissions_for_prefix(prefix_instance)
+        prefix_instance.save()
         return prefix_instance
 
     @transaction.atomic
     def update(self, validated_data):
-        """Update function for Prefix."""
+        """Update function for Prefix
+
+        """
+
         prefix_instance = Prefix.objects.get(prefix=validated_data['prefix'])
+        prefix_name = prefix_instance.prefix
         if prefix_instance.owner != validated_data['owner']:
             return "denied"
+        if prefix_instance.public != validated_data['public']:
+            prefix_instance.public = validated_data['public']
+            #TODO: handle adding/deleting permissions for change of public status
+        update_user_permissions(prefix_name,validated_data['user_permissions'])
         prefix_instance.description = validated_data.get('description', prefix_instance.description)
         prefix_instance.save()
+        prefix_object = get_prefix_object(prefix_name)
+        return prefix_object
 
-        return prefix_instance
+def update_user_permissions(prefix_name: str, user_permissions: dict):
+    """Udate Prefix Permissions
 
-def create_permissions_for_prefix(instance=None, owner=User):
+    Update user permissions based on a provided mapping of users to permissions.
+    Only modifies permissions related to the specified prefix.
+    Step 1: Build a list of permissions associated with the prefix
+    Step 2: Iterate over the user_permissions dict to update each user
+    Step 3: Find which permissions to add (from the provided list) and which to remove
+    Step 4: Add new permissions and remove old ones not in the new list
+    """
+
+    prefix_permissions = []
+    for perm_type in ["view", "add", "change", "delete", "publish"]:
+        codename = f"{perm_type}_{prefix_name}"
+        try:
+            perm = Permission.objects.get(codename=codename)
+            prefix_permissions.append(perm)
+        except Permission.DoesNotExist:
+            # If the permission doesn't exist, skip it
+            pass
+
+    prefix_permissions_dict = {
+        perm.codename: perm for perm in prefix_permissions
+    }
+
+    for username, perms in user_permissions.items():
+        try:
+            user = User.objects.get(username=username)
+            current_perms = set(user.user_permissions.filter(
+                pk__in=[permission.pk for permission in prefix_permissions])
+            )
+            new_perms = {
+                prefix_permissions_dict[perm_codename] for perm_codename \
+                in perms if perm_codename in prefix_permissions_dict
+            }
+
+            perms_to_add = new_perms - current_perms
+            perms_to_remove = current_perms - new_perms
+
+            if perms_to_add:
+                user.user_permissions.add(*perms_to_add)
+            if perms_to_remove:
+                user.user_permissions.remove(*perms_to_remove)
+
+        except User.DoesNotExist:
+            # Handle case where user doesn't exist if necessary
+            pass
+
+
+def create_permissions_for_prefix(instance=Prefix):
     """Prefix Permission Creation
 
     Creates permissions for a Prefix if it is not public. Owner is assigned
@@ -81,17 +143,20 @@ def create_permissions_for_prefix(instance=None, owner=User):
 	'delete' -> Delete drafts for Prefix
 	'publish' -> Publish drafts for Prefix
     """
+
     try:
         for perm in [ "view", "add", "change", "delete", "publish"]:
-            print(instance)
-            Permission.objects.create(
+            new_perm = Permission.objects.create(
                 name="Can " + perm + " BCOs with prefix " + instance.prefix,
-                content_type=ContentType.objects.get(app_label="api", model="bco"),
+                content_type=ContentType.objects.get(app_label="prefix", model="prefix"),
                 codename=perm + "_" + instance.prefix,)
-    except:
-        return 0
+            instance.owner.user_permissions.add(new_perm)
 
-def prefix_counter_increment(prefix: Prefix) -> int:
+    except utils.IntegrityError:
+        # The permissions already exist.
+        pass
+
+def prefix_counter_increment(prefix_instance: Prefix) -> int:
     """Prefix Counter Increment 
     
     Simple incrementing function.
@@ -99,18 +164,36 @@ def prefix_counter_increment(prefix: Prefix) -> int:
     """
     
     Prefix.objects.update(counter=F("counter") + 1)
-    count = prefix.counter
+    count = prefix_instance.counter
     return count
 
-def delete_prefix(prefix: str, user: User) -> bool:
+@transaction.atomic
+def delete_prefix(prefix_name: str, user: User) -> bool:
     """Delete Prefix
+
+    Deletes a prefix and the permissions.
+    `view` and `delete` permissions are not removed so that existing BCOs can
+    still be viewed or individually removed.
+    
+    'add' -> create new drafts for Prefix
+	'change' -> Change existing drafts for Prefix
+	'publish' -> Publish drafts for Prefix
     """
+
     try:
-        prefix_instance = Prefix.objects.get(prefix=prefix)
+        prefix_instance = Prefix.objects.get(prefix=prefix_name)
     except Prefix.DoesNotExist:
-        return f"That prefix, {prefix}, does not exist."
+        return f"That prefix, {prefix_name}, does not exist."
+
     if prefix_instance.owner == user:
         prefix_instance.delete()
+        if prefix_instance.public is False:
+            for perm in ["add", "change",  "publish"]:
+                try:
+                    Permission.objects.get(codename=f"{perm}_{prefix_name}").delete()
+                    print(f"{perm}_{prefix_name}")
+                except Permission.DoesNotExist:
+                    pass
         return True
     
-    return f"You do not have permissions to delete that prefix, {prefix}."
+    return f"You do not have permissions to delete that prefix, {prefix_name}."

--- a/prefix/urls.py
+++ b/prefix/urls.py
@@ -5,10 +5,18 @@
 """
 
 from django.urls import path
-from prefix.apis import PrefixesCreateApi, PrefixesDeleteApi, PrefixesModifyApi
+from prefix.apis import (
+    PrefixesCreateApi,
+    PrefixesDeleteApi,
+    PrefixesModifyApi,
+    PrefixGetInfoApi,
+    PrefixesForUserApi
+)
 
 urlpatterns = [
     path("prefixes/create/", PrefixesCreateApi.as_view()),
     path("prefixes/delete/", PrefixesDeleteApi.as_view()),
     path("prefixes/modify/", PrefixesModifyApi.as_view()),
+    path("prefixes/user/",   PrefixesForUserApi.as_view()),
+    path("prefixes/info/",   PrefixGetInfoApi.as_view()),
 ]

--- a/tests/test_views/test_api_objects_drafts_create.py
+++ b/tests/test_views/test_api_objects_drafts_create.py
@@ -42,10 +42,10 @@ class BcoDraftCreateTestCase(TestCase):
                 "prefix": "BCO",
                 "authorized_users": ["hivelab"],
                 "contents": {
-                "object_id": "https://test.portal.biochemistry.gwu.edu/BCO_000001/DRAFT",
-                "spec_version": "https://w3id.org/ieee/ieee-2791-schema/2791object.json",
-                "etag": "11ee4c3b8a04ad16dcca19a6f478c0870d3fe668ed6454096ab7165deb1ab8ea"
-                }
+                    "object_id": "https://test.portal.biochemistry.gwu.edu/BCO_000001/DRAFT",
+                    "spec_version": "https://w3id.org/ieee/ieee-2791-schema/2791object.json",
+                    "etag": "11ee4c3b8a04ad16dcca19a6f478c0870d3fe668ed6454096ab7165deb1ab8ea"
+                    }
             },
             {
                 "object_id": "http://127.0.0.1:8000/TEST_000001",


### PR DESCRIPTION
- Prefix required it's own two groups and the creation of 5 permissions for each prefix. Look up for authentication was time consuming and taxing on DB. Users also had no idea how to use the system, just what to do to make it work.
- Propose to remove `groups` altogether from the prefix model. if it is empty then anyone can use it. If populated than only with the permission can use it
